### PR TITLE
Fix: iOS knob pan gesture not working

### DIFF
--- a/Scr/Switch/CustomSwitch.xaml
+++ b/Scr/Switch/CustomSwitch.xaml
@@ -3,11 +3,12 @@
                  xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
                  xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
                  xmlns:view="clr-namespace:IeuanWalker.Maui.Switch">
-    <view:SwitchView.GestureRecognizers>
-        <TapGestureRecognizer Tapped="TapGestureRecognizer_Tapped" />
-    </view:SwitchView.GestureRecognizers>
     <view:SwitchView.Content>
         <Grid AutomationProperties.ExcludedWithChildren="True" AutomationProperties.IsInAccessibleTree="False">
+            <Grid.GestureRecognizers>
+                <TapGestureRecognizer Tapped="TapGestureRecognizer_Tapped" />
+                <PanGestureRecognizer PanUpdated="PanGestureRecognizer_PanUpdated" />
+            </Grid.GestureRecognizers>
             <Border x:Name="BackgroundFrame"
                     Padding="0"
                     Background="{Binding Background, Source={RelativeSource AncestorType={x:Type ContentView}}}"
@@ -19,12 +20,7 @@
                     StrokeShape="{Binding StrokeShape, Source={RelativeSource AncestorType={x:Type ContentView}}}"
                     StrokeThickness="{Binding StrokeThickness, Source={RelativeSource AncestorType={x:Type ContentView}}}"
                     VerticalOptions="Center"
-                    WidthRequest="{Binding WidthRequest, Source={RelativeSource AncestorType={x:Type ContentView}}}">
-                <Border.GestureRecognizers>
-                    <TapGestureRecognizer Tapped="TapGestureRecognizer_Tapped" />
-                    <PanGestureRecognizer PanUpdated="PanGestureRecognizer_PanUpdated" />
-                </Border.GestureRecognizers>
-            </Border>
+                    WidthRequest="{Binding WidthRequest, Source={RelativeSource AncestorType={x:Type ContentView}}}" />
             <Border x:Name="KnobFrame"
                     Padding="0"
                     Background="{Binding KnobBackground, Source={RelativeSource AncestorType={x:Type ContentView}}}"


### PR DESCRIPTION
On iOS the pangesture wasnt triggering when trying to manually drag the knob, but working on android.

Issue was the pangesture was added to the switch background control, and on iOS overlaying controls hides the underlining gestures.

Fixed by moving the gestures up a level, so it covers the background + knob