### PR TITLE
Update CustomSwitch.xaml.cs

### DIFF
--- a/Scr/Switch/CustomSwitch.xaml.cs
+++ b/Scr/Switch/CustomSwitch.xaml.cs
@@ -375,7 +375,7 @@ public partial class CustomSwitch : SwitchView
 
 	static void SizeRequestChanged(BindableObject bindable, object oldValue, object newValue)
 	{
-		if(bindable is not CustomSwitch view)
+		if(bindable is not CustomSwitch view || !view.HasLoaded)
 		{
 			return;
 		}


### PR DESCRIPTION
I met an exception when using a Style dictionary to style CustomSwitchs, with KnobFrame and BackgroundFrame being null when SizeRequestChanged is called for the first time. Adding HasLoaded in the check at the beginning of the method seems to fix this issue.